### PR TITLE
Fix failed Travis test on tip

### DIFF
--- a/mmd/mmd_test.go
+++ b/mmd/mmd_test.go
@@ -1,4 +1,5 @@
 // +build integration
+
 package mmd
 
 import (


### PR DESCRIPTION
Fix: +build comment must appear before package clause and be followed by a blank line