### PR TITLE
Increase buffer size correctly and double capacity

### DIFF
--- a/mmd/buffer.go
+++ b/mmd/buffer.go
@@ -136,10 +136,9 @@ func (b *Buffer) doubleCapacity() {
 	if newCapacity == 0 {
 		newCapacity = 1
 	}
-	tmp := make([]byte, cap(b.data))
+	tmp := make([]byte, newCapacity)
 	copy(tmp, b.data)
-	b.data = make([]byte, newCapacity)
-	copy(b.data, tmp)
+	b.data = tmp
 }
 
 func (b *Buffer) ReadVaruint() (uint, error) {

--- a/mmd/buffer.go
+++ b/mmd/buffer.go
@@ -128,7 +128,18 @@ func (b *Buffer) ensureSpace(sz int) {
 	if cap(b.data) > need {
 		return
 	}
-	copy(make([]byte, cap(b.data)+sz), b.data)
+	b.doubleCapacity()
+}
+
+func (b *Buffer) doubleCapacity() {
+	newCapacity := cap(b.data) * 2
+	if newCapacity == 0 {
+		newCapacity = 1
+	}
+	tmp := make([]byte, cap(b.data))
+	copy(tmp, b.data)
+	b.data = make([]byte, newCapacity)
+	copy(b.data, tmp)
 }
 
 func (b *Buffer) ReadVaruint() (uint, error) {


### PR DESCRIPTION
After being initialized to a default value of 1024, the ensureCapacity() function had a bug which would not increase the capacity of the buffer slice to what was required. This will correctly increase the size, doing this by double the current capacity of the slice. It was found that doubling the current capacity is faster than appending and re-slicing.