### PR TITLE
Struct encoding fix

### DIFF
--- a/mmd/encoder.go
+++ b/mmd/encoder.go
@@ -245,8 +245,9 @@ func reflectEncode(thing interface{}, buffer *Buffer) error {
 		buffer.WriteByte(0x04)
 		si := getStructInfo(val.Type())
 
+		// Store the absolute position since buffer can resize and reserve space to add size later
 		sz_pos := buffer.GetPos()
-		buffer.GetWritable(4) // Reserve space for size
+		buffer.GetWritable(4)
 
 		count := 0
 		for _, f := range si.fields {
@@ -266,6 +267,7 @@ func reflectEncode(thing interface{}, buffer *Buffer) error {
 
 		}
 		if count > 0 {
+			// Fill in size at the reserved space
 			cur_pos := buffer.GetPos()
 			buffer.Position(sz_pos)
 			buffer.order.PutUint32(buffer.GetWritable(4), uint32(count))

--- a/mmd/encoder.go
+++ b/mmd/encoder.go
@@ -163,6 +163,9 @@ func getStructInfo(st reflect.Type) *structInfo {
 			n = f.Tag.Get("json")
 		}
 		if n != "" {
+			if n == "-" {
+				continue
+			}
 			parts := strings.Split(n, ",")
 			if parts[0] != "" {
 				fi.key = parts[0]

--- a/mmd/encoder.go
+++ b/mmd/encoder.go
@@ -241,7 +241,10 @@ func reflectEncode(thing interface{}, buffer *Buffer) error {
 		buffer.WriteByte('r')
 		buffer.WriteByte(0x04)
 		si := getStructInfo(val.Type())
-		sz := buffer.GetWritable(4)
+
+		sz_pos := buffer.GetPos()
+		buffer.GetWritable(4) // Reserve space for size
+
 		count := 0
 		for _, f := range si.fields {
 			fv := fieldByIndex(val, f.num)
@@ -260,7 +263,10 @@ func reflectEncode(thing interface{}, buffer *Buffer) error {
 
 		}
 		if count > 0 {
-			buffer.order.PutUint32(sz, uint32(count))
+			cur_pos := buffer.GetPos()
+			buffer.Position(sz_pos)
+			buffer.order.PutUint32(buffer.GetWritable(4), uint32(count))
+			buffer.Position(cur_pos)
 		} else {
 			buffer.Position(start)
 			buffer.WriteByte('N')


### PR DESCRIPTION
* Ensure size is set if buffer gets resized
* Omit fields with "-" tag to match go json marshaling convention