### PR TITLE
Remove custom logging

### DIFF
--- a/mmd/compositeconn.go
+++ b/mmd/compositeconn.go
@@ -3,6 +3,7 @@ package mmd
 import (
 	"context"
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"reflect"

--- a/mmd/conn.go
+++ b/mmd/conn.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"reflect"
 	"sync"

--- a/mmd/mmd.go
+++ b/mmd/mmd.go
@@ -2,12 +2,10 @@ package mmd
 
 import (
 	"flag"
-	logpkg "log"
 	"os"
 	"strconv"
 )
 
-var log = logpkg.New(os.Stdout, "[mmd] ", logpkg.LstdFlags|logpkg.Lmicroseconds)
 var mmdUrl = "localhost:9999"
 
 func init() {

--- a/mmd/server.go
+++ b/mmd/server.go
@@ -2,6 +2,7 @@ package mmd
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"time"
 )


### PR DESCRIPTION
In order to let clients that use this library determine where logging should go, we need to remove the logpkg logger, and import the default golang logger where necessary