### PR TITLE
PLAT-1609: call onConnect handler when istio service reconnects(fix 1)

### DIFF
--- a/mmd/compositeconn.go
+++ b/mmd/compositeconn.go
@@ -131,8 +131,8 @@ func (c *CompositeConn) registerDirectService(service string, fn ServiceFunc) er
 	return nil
 }
 
-func (c *CompositeConn) createSocketConnection(isRetryConnection bool) error {
-	return c.mmdConn.createSocketConnection(isRetryConnection)
+func (c *CompositeConn) createSocketConnection(isRetryConnection bool, isCompositeConn bool) error {
+	return c.mmdConn.createSocketConnection(isRetryConnection, isCompositeConn)
 }
 
 func (c *CompositeConn) close() (err error) {
@@ -226,11 +226,10 @@ func (c *CompositeConn) createAndInitDirectConnection(service string) (*ConnImpl
 	newConfig.Url = newUrl
 
 	newConfig.ConnTimeout = DIRECT_CONNECTION_TIMEOUT_SECONDS
-	newConfig.OnConnect = nil
 
 	conn := createConnection(&newConfig)
 
-	err = conn.createSocketConnection(false)
+	err = conn.createSocketConnection(false, true)
 	if err != nil {
 		return nil, err
 	}

--- a/mmd/conn.go
+++ b/mmd/conn.go
@@ -262,15 +262,14 @@ func (c *ConnImpl) createSocketConnection(isRetryConnection bool, isCompositeCon
 			tcpConn.SetReadBuffer(c.config.ReadSz)
 			c.socket = tcpConn
 
-			shouldCallOnConnect := !isRetryConnection || !isCompositeConn
-			return c.onSocketConnection(shouldCallOnConnect)
+			return c.onSocketConnection(isRetryConnection, isCompositeConn)
 		}
 
 		return err
 	}
 }
 
-func (c *ConnImpl) onSocketConnection(shouldCallConnect bool) error {
+func (c *ConnImpl) onSocketConnection(isRetryConnection bool, isCompositeConn bool) error {
 	//either write or read the handshake
 	if c.config.WriteHandshake {
 		err := c.handshake()
@@ -290,7 +289,8 @@ func (c *ConnImpl) onSocketConnection(shouldCallConnect bool) error {
 		c.Call("$mmd", map[string]interface{}{"extraTheirTags": c.config.ExtraTheirTags})
 	}
 
-	if c.config.OnConnect != nil && shouldCallConnect {
+	shouldCallOnConnect := isRetryConnection || !isCompositeConn
+	if c.config.OnConnect != nil && shouldCallOnConnect {
 		return c.config.OnConnect(c)
 	}
 

--- a/mmd/connconfig.go
+++ b/mmd/connconfig.go
@@ -56,7 +56,7 @@ func _create_connection(cfg *ConnConfig) (Conn, error) {
 		mmdc = createConnection(cfg)
 	}
 
-	err := mmdc.createSocketConnection(false)
+	err := mmdc.createSocketConnection(false, true)
 	if err != nil {
 		return nil, err
 	}

--- a/mmd/connconfig.go
+++ b/mmd/connconfig.go
@@ -56,7 +56,7 @@ func _create_connection(cfg *ConnConfig) (Conn, error) {
 		mmdc = createConnection(cfg)
 	}
 
-	err := mmdc.createSocketConnection(false, true)
+	err := mmdc.createSocketConnection(false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/mmd/server.go
+++ b/mmd/server.go
@@ -71,7 +71,7 @@ func (s *Server) handleConnection(tcpConn *net.TCPConn) (err error) {
 	mmdConn := createConnectionForTcpConn(serverConfig, tcpConn)
 
 	mmdConn.services[s.serviceName] = s.serviceFunc
-	return mmdConn.onSocketConnection()
+	return mmdConn.onSocketConnection(false)
 }
 
 func createServerSideConnCfg(clientConfig *ConnConfig) *ConnConfig {

--- a/mmd/server.go
+++ b/mmd/server.go
@@ -71,13 +71,12 @@ func (s *Server) handleConnection(tcpConn *net.TCPConn) (err error) {
 	mmdConn := createConnectionForTcpConn(serverConfig, tcpConn)
 
 	mmdConn.services[s.serviceName] = s.serviceFunc
-	return mmdConn.onSocketConnection(false)
+	return mmdConn.onSocketConnection(false, true)
 }
 
 func createServerSideConnCfg(clientConfig *ConnConfig) *ConnConfig {
 	newCfg := *clientConfig
 	newCfg.WriteHandshake = false
-	newCfg.OnConnect = nil
 	return &newCfg
 }
 


### PR DESCRIPTION
Composite conn:

- Create a normal MMD connection on start and onConnect handler is bundled with this connection
- Client: lazy create connection when Call/Subscribe (onConnect = nil)
- Server: spin up server when Register (onConnect = nil)  

Current behavior is: 
1. onConnect will be called when MMD connect/reconnect
2. Istio service reconnect will not call onConnect     <— (this PR is fixing this)
3. No restart/reconnect logic in Istio server     <— (working on figuring out what we can do about this)