### PR TITLE
fix issue with Subscribe returning no error

### DIFF
--- a/mmd/conn.go
+++ b/mmd/conn.go
@@ -298,7 +298,7 @@ func (c *ConnImpl) onSocketConnection(notifyOnConnect bool) error {
 }
 
 func (c *ConnImpl) checkConnectionStateWithRead() error {
-	if err := c.socket.SetReadDeadline(time.Now().Add(1000 * time.Millisecond)); err != nil {
+	if err := c.socket.SetReadDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {
 		return fmt.Errorf("failed to set read deadline, reason: %v", err)
 	}
 	err, _ := c.readSingleFrame()

--- a/mmd/conn.go
+++ b/mmd/conn.go
@@ -180,8 +180,8 @@ func ConnectWithTagsWithRetryTo(url string, myTags []string, theirTags []string,
 
 // internal to package --
 
-func (c *ConnImpl) startReader(wg *sync.WaitGroup) {
-	go c.reader(wg)
+func (c *ConnImpl) startReader() {
+	go c.reader()
 }
 
 func (c *ConnImpl) cleanupReader() {
@@ -272,35 +272,19 @@ func (c *ConnImpl) createSocketConnection(isRetryConnection bool, notifyOnConnec
 func (c *ConnImpl) onSocketConnection(notifyOnConnect bool) error {
 	//either write or read the handshake
 	if c.config.WriteHandshake {
-		err := c.handshake()
-		if err != nil {
+		if err := c.handshake(); err != nil {
+			return err
+		}
+		if err := c.checkConnectionStateWithRead(); err != nil {
 			return err
 		}
 	} else {
-		err, _ := c.readSingleFrame()
-		if err != nil {
+		if err, _ := c.readSingleFrame(); err != nil {
 			return err
 		}
 	}
 
-	// This is a convoluted way to ensure that Subscribe calls to this mmd client will return an error if the
-	// service is behind the Istio ingress, but is actually not healthy.
-	//
-	// We create a WaitGroup that the reader thread can signal when it is complete with its first pass of reading.
-	//
-	// This will ensure the TCP connection is good, because the Istio ingress will accept TCP connections
-	// for services that may not be available. Additionally, we cannot detect that the service is not there simply by
-	// Writing data to the socket due to the fact that  the network stack will return a successful Write call
-	// so long as the data makes it to the kernel's network buffer.
-	//
-	// If the reader detects an error, it will shutdown the socket, and will cause any subsequent Writes
-	// to fail as well. This gives the opportunity to return an Error from the Subscribe call.
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-
-	c.startReader(wg)
-
-	wg.Wait()
+	c.startReader()
 
 	if len(c.config.ExtraTheirTags) > 0 {
 		c.Call("$mmd", map[string]interface{}{"extraTheirTags": c.config.ExtraTheirTags})
@@ -310,6 +294,22 @@ func (c *ConnImpl) onSocketConnection(notifyOnConnect bool) error {
 		return c.config.OnConnect(c)
 	}
 
+	return nil
+}
+
+func (c *ConnImpl) checkConnectionStateWithRead() error {
+	if err := c.socket.SetReadDeadline(time.Now().Add(1000 * time.Millisecond)); err != nil {
+		return fmt.Errorf("failed to set read deadline, reason: %v", err)
+	}
+	err, _ := c.readSingleFrame()
+	if err != nil {
+		if !errors.Is(err, os.ErrDeadlineExceeded) {
+			return err
+		}
+	}
+	if err := c.socket.SetReadDeadline(time.Time{}); err != nil {
+		return fmt.Errorf("failed to clear read deadline, reason: %v", err)
+	}
 	return nil
 }
 
@@ -405,8 +405,7 @@ func (c *ConnImpl) writeOnSocket(data []byte) error {
 	return nil
 }
 
-func (c *ConnImpl) reader(wg *sync.WaitGroup) {
-	firstPass := true
+func (c *ConnImpl) reader() {
 	fszb := make([]byte, 4)
 	buff := make([]byte, 256)
 	defer func() {
@@ -418,35 +417,8 @@ func (c *ConnImpl) reader(wg *sync.WaitGroup) {
 	}()
 
 	for {
-		if firstPass {
-			// On the first pass of the reader we want to use the Read to check the state of the
-			// TCP connection, so we must set a ReadDeadline, otherwise the Read call will block until data is present.
-			// If the TCP connection is bad, the Read call will return an error other than ErrDeadlineExceeded,
-			// most likely an EOF
-			_ = c.socket.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
-		}
 		err, b := c.readFrame(fszb, buff)
-		if firstPass {
-			// After the first pass of the Read, we reset the deadline to 0, which disables
-			// it, any subsequent Read calls on the TCP connection will block until data is
-			// available.
-			_ = c.socket.SetReadDeadline(time.Time{})
-			// We also signal the WaitGroup that we are done so the goroutine that is setting
-			// up this connection can finish its processing
-			wg.Done()
-			firstPass = false
-		}
 		if err != nil {
-			if errors.Is(err, os.ErrDeadlineExceeded) {
-				// We are expecting a DeadlineExceeded error on the first pass, so we just
-				// continue at the top of the for loop.
-				// This block of code should never run on subsequent iterations of
-				// the loop because we have disabled the deadline above.
-				continue
-			}
-			// Any other error received, regardless of first pass or not, indicates
-			// there is a problem with the TCP connection, and we should exit the reader loop.
-			// The deferred function will take care of the cleanup.
 			return
 		}
 		m, err := Decode(b)


### PR DESCRIPTION
If an Istio service is behind the ingress, but is unhealthy, Subscribe
calls will not return an error. this is because the ingress actually
accepts the tcp connection, and write calls to the socket are
buffered in the kernel and no error is returned from this call either.

The only way to detect that the service is unavailable is to attempt to
read from it.

This solution will setup a wait group and the goroutine that is creating the
connection will wait on this. The reader thread will signal hthis wait group
after it has done an initial read on the socket and determined that it is OK.
The creating goroutine is then released to finish the subscribe call.

If the service is unhealthy, then the reader will close the socket and
the still release the wait group. The write to the now closed socket will fail
giving the mmd client the opportunity to properly return an error to
the caller.