### PR TITLE
Plat 2247 fix deadlock v2

### DIFF
--- a/mmd/conn.go
+++ b/mmd/conn.go
@@ -107,7 +107,7 @@ func (c *ConnImpl) GetDefaultCallTimeout() time.Duration {
 	return c.callTimeout
 }
 
-func (c ConnImpl) String() string {
+func (c *ConnImpl) String() string {
 	return fmt.Sprintf("ConnImpl{remote: %s, local: %s}", c.socket.RemoteAddr(), c.socket.LocalAddr())
 }
 
@@ -429,7 +429,7 @@ func (c *ConnImpl) readFrame(fszb []byte, buff []byte) (error, *Buffer) {
 		if err != io.EOF {
 			// error expected for composite connection or first read with a Deadline Exceeded,
 			// so no need to log this error.
-			if c.config.OnDisconnect == nil && !errors.Is(err, os.ErrDeadlineExceeded){
+			if c.config.OnDisconnect == nil && !errors.Is(err, os.ErrDeadlineExceeded) {
 				log.Println("Error reading frame size:", err)
 			}
 		}

--- a/mmd/conn.go
+++ b/mmd/conn.go
@@ -465,7 +465,7 @@ func (c *ConnImpl) readFrame(fszb []byte, buff []byte) (error, *Buffer) {
 func (c *ConnImpl) dispatchMessage(m interface{}) {
 	defer func() {
 		if dispatchErr := recover(); dispatchErr != nil {
-			log.Println("recovered from panic while dispatching message. Details: %v", dispatchErr)
+			fmt.Println("recovered from panic while dispatching message. Details: ", dispatchErr)
 		}
 	}()
 	switch msg := m.(type) {

--- a/mmd/mmd_test.go
+++ b/mmd/mmd_test.go
@@ -3,12 +3,13 @@
 package mmd
 
 import (
+	"log"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
 	"strconv"
+	"sync"
 	"testing"
-	"log"
 )
 
 var integrationTests = false
@@ -101,18 +102,14 @@ func TestCloseChannelRecover(t *testing.T) {
 
 	err = mmdc.RegisterService("test.service", func(conn Conn, channel *Chan, channelCreate *ChannelCreate) {
 		if channelCreate.Type == SubChan {
-			go func() {
-				wg.Wait()
-				next := <-channel.Ch
-			}()
-
+			wg.Wait()
 			err := channel.Send("sub response")
 			if err != nil {
 				t.Logf("Service error sending sub response: %s", err)
 			}
 		}
 	})
-
+	
 	subChan, err := mmdc.Subscribe("test.service", "sub message")
 	close(subChan.Ch)
 	wg.Done()

--- a/mmd/mmd_test.go
+++ b/mmd/mmd_test.go
@@ -86,11 +86,12 @@ func TestRegister(t *testing.T) {
 }
 
 func TestCloseChannelRecover(t *testing.T) {
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
 	if !integrationTests {
 		t.Skip("integration tests disabled")
 	}
+	
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
 
 	mmdc, err := Connect()
 	if err != nil {

--- a/mmd/mmd_test.go
+++ b/mmd/mmd_test.go
@@ -3,6 +3,7 @@
 package mmd
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	_ "net/http/pprof"
@@ -97,6 +98,11 @@ func TestCloseChannelRecover(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		if closeErr := recover(); closeErr != nil {
+			fmt.Println("Expected, recovered from panic on closeConnection")
+		}
+	} ()
 	defer closeConnection(t, mmdc)
 
 	t.Log("Created mmd connection:", mmdc)


### PR DESCRIPTION
This PR is a second attempt at addressing the deadlock issues seen when receiving sub messages.

-undo all changes from go-mmd v1.1.16
-no longer holding the dispatchLock when closing a dispatch channel or sending messages to a dispatch channel
-recovering from potential panics that can occur when sending or closing a dispatch channel that is in a composite connection when the mmd connection disconnects
-added a unit test to verify the recovery mechanism works

the branch that this PR is merging to `revert-39-fix-send-msg-deadlock`, just has a commit that reverts the first deadlock fix attempt(go-mmd v1.1.16), see https://github.com/peak6/go-mmd/compare/master...revert-39-fix-send-msg-deadlock. this was split out to make it easier to identify the changes made to no longer dispatch messages within a locked section. Both will be merged to master once review and testing is complete.